### PR TITLE
Fix file uploader because of deprecated automatic encoding detection

### DIFF
--- a/index.py
+++ b/index.py
@@ -19,7 +19,7 @@ archiver = Archiver(
 session = boto3.session.Session()
 client = session.client(
     "s3",
-    region_name="S3_REGION",
+    region_name="nyc3",
     endpoint_url=os.environ.get("AWS_S3_ENDPOINT", ""),
     aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", ""),
     aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),

--- a/index.py
+++ b/index.py
@@ -6,6 +6,7 @@ import streamlit as st
 import json
 import boto3
 import os
+import io
 
 conn = create_engine(os.environ.get("RECIPE_ENGINE"))
 archiver = Archiver(
@@ -126,7 +127,8 @@ _path = metadata.get("path", "")
 if upload:
     acl = st.radio("ACL", ("public-read", "private"), index=1)
     ext = st.selectbox("Pick your file type", ["csv", "geojson", "zip"], index=0)
-    newfile = st.file_uploader("upload new", type=[ext])
+    file_buffer = st.file_uploader("upload new", type=[ext])
+    newfile = io.TextIOWrapper(file_buffer)
     path = write_to_s3(newfile, schema, version_name, acl, ext, client=client)
 else:
     path = st.text_input("path", _path)


### PR DESCRIPTION
Responding to warning on streamlit, which was causing errors:

> FileUploaderEncodingWarning: The behavior of st.file_uploader will soon change to no longer autodetect the file's encoding. This means that all files will be returned as binary buffers.
> 
> This change will go in effect after August 15, 2020.
> 
> If you are expecting a text buffer, you can future-proof your code now by wrapping the returned buffer in a TextIOWrapper, as shown below:
> 
> ```python
> import io
> 
> file_buffer = st.file_uploader(...)
> text_io = io.TextIOWrapper(file_buffer)
> ```
> 